### PR TITLE
feat: :sparkles: new issue page 기능 구현 완료

### DIFF
--- a/FE/issue-tracker/src/Components/Home/HomeContents/CreateIssueButton.tsx
+++ b/FE/issue-tracker/src/Components/Home/HomeContents/CreateIssueButton.tsx
@@ -1,7 +1,12 @@
+import { Link } from "react-router-dom";
 import { Home as S } from "../HomeStyles";
 
 const CreateIssueButton = () => {
-  return <S.WriteIssueBtn>+ 이슈작성</S.WriteIssueBtn>;
+  return (
+    <Link to="/newIssue">
+      <S.WriteIssueBtn>+ 이슈작성</S.WriteIssueBtn>
+    </Link>
+  );
 };
 
 export default CreateIssueButton;

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetail.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetail.tsx
@@ -2,7 +2,9 @@ import IssueDetailHeader from "./IssueDetailHeader/IssueDetailHeader";
 import IssueContents from "./IssueContents/IssueContents";
 import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 
-const IssueDetail = () => {
+const IssueDetail = ({ location }: any) => {
+  console.log(location);
+  //useEffect로 set된 이슈넘버를 get해옴. 그 후에 issueDetailState에 저장
   return (
     <S.IssueDetail>
       <IssueDetailHeader />

--- a/FE/issue-tracker/src/Components/NewIssue/CreateButton.tsx
+++ b/FE/issue-tracker/src/Components/NewIssue/CreateButton.tsx
@@ -1,18 +1,34 @@
 import { useRecoilValue } from "recoil";
+import { Link } from "react-router-dom";
 import { createButtonFlagState } from "@/Components/NewIssue/NewIssueStore";
 import { NewIssue as S } from "@/Components/NewIssue/NewIssueStyles";
 
 const CreateButton = () => {
   const createButtonFlag = useRecoilValue(createButtonFlagState);
 
+  const handleOnClick = (e: any) => {
+    if (e.target.childNodes[0].disabled) e.preventDefault();
+    console.log(
+      "이슈 등록 -> 저장된 이슈 넘버 받아옴 -> setIssueDetail을 해줌 -> 그러고 나서 움직여야,."
+    );
+  };
+
   return (
-    <S.CreateButton
-      variant="contained"
-      color="primary"
-      disabled={createButtonFlag}
+    <Link
+      to={{
+        pathname: "/issueDetail",
+        state: { issueId: 1 },
+      }}
+      onClick={handleOnClick}
     >
-      완료
-    </S.CreateButton>
+      <S.CreateButton
+        variant="contained"
+        color="primary"
+        disabled={createButtonFlag}
+      >
+        완료
+      </S.CreateButton>
+    </Link>
   );
 };
 

--- a/FE/issue-tracker/src/Components/NewIssue/NewIssueStyles.tsx
+++ b/FE/issue-tracker/src/Components/NewIssue/NewIssueStyles.tsx
@@ -34,9 +34,11 @@ const NewIssue = {
   `,
   NavWrapper: styled.div`
     width: 30%;
+    margin-right: 30px;
   `,
   ButtonsWrapper: styled(BOX.FLEX_ROW_BOX)`
     justify-content: flex-end;
+    align-items: center;
   `,
   CreateButton: styled(Button)`
     border-radius: 20px;
@@ -44,11 +46,12 @@ const NewIssue = {
     opacity: 0.5;
     color: ${theme.COLOR.WHITE};
     padding: 16px 24px;
-    width: 17%;
+    margin-left: 40px;
+    width: 240px;
     font-size: ${theme.FONT_SIZE.TEXT_MEDIUM};
   `,
   UnCreateButton: styled(Button)`
-    width: 8%;
+    width: 100%;
   `,
 };
 

--- a/FE/issue-tracker/src/Components/NewIssue/UnCreateButton.tsx
+++ b/FE/issue-tracker/src/Components/NewIssue/UnCreateButton.tsx
@@ -1,9 +1,12 @@
 import CloseIcon from "@material-ui/icons/Close";
+import { Link } from "react-router-dom";
 import { NewIssue as S } from "@/Components/NewIssue/NewIssueStyles";
 
 const UnCreateButton = () => {
   return (
-    <S.UnCreateButton startIcon={<CloseIcon />}>작성 취소</S.UnCreateButton>
+    <Link to="/">
+      <S.UnCreateButton startIcon={<CloseIcon />}>작성 취소</S.UnCreateButton>
+    </Link>
   );
 };
 


### PR DESCRIPTION
- Home에서 이슈 작성 버튼 누를 시 new issue page로 라우팅 처리
- 제목을 입력하면 완료 버튼 활성화
- 완료 버튼을 누르면 이슈 저장 (추후 API 적용)
- 저장 후 , 이슈 상세 페이지로 라우팅 처리 (추후 API 적용)
- 작성 취소를 누를 시 Home으로 라우팅 처리