### PR TITLE
feat: :sparkles: 이슈 상세 페이지 기능 구현 및 헤더 적용 (#47)

### DIFF
--- a/FE/issue-tracker/src/Components/AtomicComponents/Editor/Editor.tsx
+++ b/FE/issue-tracker/src/Components/AtomicComponents/Editor/Editor.tsx
@@ -6,7 +6,7 @@ interface Props {
   height: number;
   visiableDragbar: boolean;
   hideToolbar: boolean;
-  handleOnChange: (e: any) => void;
+  handleOnChange?: (e: any) => void;
 }
 
 const Editor = ({

--- a/FE/issue-tracker/src/Components/Header/HeaderStyles.tsx
+++ b/FE/issue-tracker/src/Components/Header/HeaderStyles.tsx
@@ -7,7 +7,8 @@ const Header = {
     justify-content: space-between;
     width: 100%;
     height: 94px;
-    padding: 27px 80px;
+    padding: 27px 0px;
+    margin-bottom: 30px;
     color: ${theme.GRAY_SCALE.TITLE_ACTIVE};
     font-size: ${theme.FONT_SIZE.LOGOTYPE_REGULAR};
     font-family: "Montserrat", sans-serif;

--- a/FE/issue-tracker/src/Components/Home/HomeStyles.tsx
+++ b/FE/issue-tracker/src/Components/Home/HomeStyles.tsx
@@ -14,11 +14,10 @@ const Home = {
   HomeContent: styled(BOX.FLEX_COLUMN_BOX)`
     width: 100%;
     height: fit-content;
-    padding: 0 80px;
   `,
   ContentNavDiv: styled(BOX.FLEX_ROW_BOX)`
     justify-content: space-between;
-    margin: 30px 0;
+    margin-bottom: 30px;
   `,
 
   ContentNavLeft: styled(BOX.FLEX_ROW_BOX)`

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueContents/CommentBox/Comment/Comment.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueContents/CommentBox/Comment/Comment.tsx
@@ -8,9 +8,10 @@ import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 interface Props {
   comment: any;
   isShow: boolean;
+  editComment: string;
 }
 
-const Comment = ({ isShow, comment }: Props) => {
+const Comment = ({ isShow, comment, editComment }: Props) => {
   return (
     <S.Comment data-is-show={isShow}>
       <S.CommentUpper>
@@ -24,7 +25,7 @@ const Comment = ({ isShow, comment }: Props) => {
           <SentimentSatisfiedIcon />
         </S.RightWrapper>
       </S.CommentUpper>
-      <S.CommentBottom>{comment.content}</S.CommentBottom>
+      <S.CommentBottom source={editComment} />
     </S.Comment>
   );
 };

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueContents/CommentBox/CommentBox.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueContents/CommentBox/CommentBox.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useRecoilValue } from "recoil";
 import { editCommentBoxState } from "@/Components/IssueDetail/IssueDetailStore";
 import UserImage from "../UserImage";
@@ -13,13 +14,19 @@ interface Props {
 const CommentBox = ({ comment }: Props) => {
   const editCommentBox = useRecoilValue(editCommentBoxState);
   const isShow = editCommentBox.isShow && comment.id === editCommentBox.id;
+  const [editComment, setEditComment] = useState(comment.content);
+  const [disalbed, setDisabled] = useState(true);
 
-  const handleOnChange = () => {};
+  const handleOnChange = (e: any) => {
+    if (e.length <= 0) setDisabled(true);
+    else setDisabled(false);
+    setEditComment(e);
+  };
 
   return (
     <S.CommentBox>
       <UserImage imgUrl={comment.author.image_url} />
-      <Comment isShow={isShow} comment={comment} />
+      <Comment isShow={isShow} comment={comment} editComment={editComment} />
       <S.CommentEditBox data-is-show={isShow}>
         <Editor
           value={comment.content}
@@ -30,7 +37,12 @@ const CommentBox = ({ comment }: Props) => {
         />
         <S.IssueButtonWrapper>
           <SubmitButton innerText={"편집 취소"} />
-          <SubmitButton innerText={"편집 완료"} />
+          <SubmitButton
+            innerText={"편집 완료"}
+            commentId={comment.id}
+            editComment={editComment}
+            disabled={disalbed}
+          />
         </S.IssueButtonWrapper>
       </S.CommentEditBox>
     </S.CommentBox>

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueContents/IssueContents.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueContents/IssueContents.tsx
@@ -1,17 +1,28 @@
-import { useRecoilValue } from "recoil";
-import { issueDetailState } from "@/Components/IssueDetail/IssueDetailStore";
+import { useState } from "react";
+import { useRecoilValue, useRecoilState } from "recoil";
+import {
+  issueDetailState,
+  newCommentState,
+} from "@/Components/IssueDetail/IssueDetailStore";
 import SettingSideBar from "@/Components/AtomicComponents/SettingSideBar/SettingSideBar";
 import CommentBox from "./CommentBox/CommentBox";
 import IssueDeleteButton from "./IssueDeleteButton";
-import TextArea from "@/Components/AtomicComponents/TextArea/TextArea";
+import Editor from "@/Components/AtomicComponents/Editor/Editor";
 import SubmitButton from "./SubmitButton";
 import UserImage from "./UserImage";
 import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 
 const IssueContents = () => {
   const issue = useRecoilValue(issueDetailState);
+  const [newComment, setNewComment] = useRecoilState(newCommentState);
+  const [disabled, setDisabled] = useState(true);
 
-  const handleOnChange = () => {};
+  const handleOnChange = (e: string) => {
+    if (e.length <= 0) setDisabled(true);
+    else setDisabled(false);
+    setNewComment(e);
+  };
+
   return (
     <S.IssueContentsWrapper>
       <S.IssueContents>
@@ -20,13 +31,20 @@ const IssueContents = () => {
         ))}
         <S.TextAreaWrapper>
           <UserImage imgUrl={issue.author.image_url} />
-          <TextArea
-            placeholder={"코멘트를 입력하세요"}
-            rows={10}
+          <Editor
+            value={"코멘트를 입력하세요"}
+            height={300}
+            visiableDragbar={false}
+            hideToolbar={true}
             handleOnChange={handleOnChange}
           />
         </S.TextAreaWrapper>
-        <SubmitButton innerText={"코멘트 작성"} />
+        <SubmitButton
+          innerText={"코멘트 작성"}
+          issueNumber={issue.number}
+          newComment={newComment}
+          disabled={disabled}
+        />
       </S.IssueContents>
       <S.NavWrapper>
         <SettingSideBar />

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueContents/SubmitButton.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueContents/SubmitButton.tsx
@@ -7,9 +7,14 @@ import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 
 interface Props {
   innerText: string;
+  commentId?: number;
+  editComment?: string;
+  issueNumber?: number;
+  newComment?: string;
+  disabled?: boolean;
 }
 
-const SubmitButton = ({ innerText }: Props) => {
+const SubmitButton = ({ innerText, disabled }: Props) => {
   const [editCommentBox, setEditCommentBox] =
     useRecoilState(editCommentBoxState);
   const makeButton = () => {
@@ -17,8 +22,12 @@ const SubmitButton = ({ innerText }: Props) => {
       return (
         <S.IssueSubmitButton
           data-is-outlined={false}
+          disabled={disabled}
           variant="contained"
           color="primary"
+          onClick={() => {
+            // POST(issueNumber,newComment)
+          }}
         >
           <AddIcon />
           코멘트 작성
@@ -28,8 +37,13 @@ const SubmitButton = ({ innerText }: Props) => {
       return (
         <S.IssueSubmitButton
           data-is-outlined={false}
+          disabled={disabled}
           variant="contained"
           color="primary"
+          onClick={
+            () => setEditCommentBox({ ...editCommentBox, isShow: false })
+            // PATCH(commentId,editComment)
+          }
         >
           <BorderColorIcon />
           편집 완료

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetail.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetail.tsx
@@ -1,15 +1,19 @@
 import IssueDetailHeader from "./IssueDetailHeader/IssueDetailHeader";
 import IssueContents from "./IssueContents/IssueContents";
+import Header from "@/Components/Header/Header";
 import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 
 const IssueDetail = ({ location }: any) => {
   console.log(location);
   //useEffect로 set된 이슈넘버를 get해옴. 그 후에 issueDetailState에 저장
   return (
-    <S.IssueDetail>
-      <IssueDetailHeader />
-      <IssueContents />
-    </S.IssueDetail>
+    <>
+      <Header />
+      <S.IssueDetail>
+        <IssueDetailHeader />
+        <IssueContents />
+      </S.IssueDetail>
+    </>
   );
 };
 

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetailHeader/IssueControlButton.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetailHeader/IssueControlButton.tsx
@@ -24,9 +24,10 @@ const IssueControlButton = ({ innerText }: Props) => {
         // 이슈 업데이트 api 사용
       }
       setEditTitleFlag((prev) => !prev);
-    } else {
+    } else if (editButton === "이슈 닫기") {
       // 이슈 닫기이면 이슈 닫기 api
-      return;
+    } else {
+      // 이슈 열기이면 이슈 열기 api
     }
   };
 

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetailHeader/IssueDetailHeader.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetailHeader/IssueDetailHeader.tsx
@@ -1,3 +1,5 @@
+import { useRecoilValue } from "recoil";
+import { issueDetailState } from "@/Components/IssueDetail/IssueDetailStore";
 import Title from "./Title";
 import IssueNumber from "./IssueNumber";
 import IssueControlButton from "./IssueControlButton";
@@ -5,6 +7,8 @@ import Description from "./Description";
 import { IssueDetail as S } from "@/Components/IssueDetail/IssueDetailStyles";
 
 const IssueDetailHeader = () => {
+  const issue = useRecoilValue(issueDetailState);
+
   return (
     <S.IssueDetailHeader>
       <S.HeaderUpper>
@@ -14,7 +18,9 @@ const IssueDetailHeader = () => {
         </S.TitleWrapper>
         <div>
           <IssueControlButton innerText={"제목 편집"} />
-          <IssueControlButton innerText={"이슈 닫기"} />
+          <IssueControlButton
+            innerText={issue.is_open ? "이슈 닫기" : "이슈 열기"}
+          />
         </div>
       </S.HeaderUpper>
       <Description />

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetailStore.ts
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetailStore.ts
@@ -70,3 +70,8 @@ export const editCommentBoxState = atom({
   key: "editCommentBoxState",
   default: { isShow: false, id: 0 },
 });
+
+export const newCommentState = atom({
+  key: "newCommentState",
+  default: "",
+});

--- a/FE/issue-tracker/src/Components/IssueDetail/IssueDetailStyles.tsx
+++ b/FE/issue-tracker/src/Components/IssueDetail/IssueDetailStyles.tsx
@@ -4,15 +4,15 @@ import theme from "@/Styles/theme";
 import Button from "@material-ui/core/Button";
 import Avatar from "@material-ui/core/Avatar";
 import BorderColorIcon from "@material-ui/icons/BorderColor";
+import MDEditor from "@uiw/react-md-editor";
 
 const IssueDetail = {
   IssueDetail: styled.div`
     width: 100%;
-    margin-top: 30px;
   `,
   IssueDetailHeader: styled.div`
     width: 100%;
-    padding: 30px 0px;
+    padding-bottom: 30px;
     border-bottom: 1px solid ${theme.GRAY_SCALE.LINE};
   `,
   HeaderUpper: styled(BOX.FLEX_ROW_BOX)`
@@ -83,6 +83,9 @@ const IssueDetail = {
     color: ${(props) =>
       props["data-is-outlined"] ? theme.COLOR.BLUE : theme.COLOR.WHITE};
     padding: 10px 24px;
+    :disabled {
+      border: 2px solid ${theme.GRAY_SCALE.LINE};
+    }
   `,
   CommentBox: styled(BOX.FLEX_ROW_BOX)`
     width: 100%;
@@ -112,7 +115,7 @@ const IssueDetail = {
     border-radius: 16px 16px 0px 0px;
     border-bottom: 1px solid ${theme.GRAY_SCALE.LINE};
   `,
-  CommentBottom: styled.div`
+  CommentBottom: styled(MDEditor.Markdown)`
     width: 100%;
     padding: 18px 24px;
     border-radius: 0px 0px 16px 16px;

--- a/FE/issue-tracker/src/Components/NewIssue/NewIssue.tsx
+++ b/FE/issue-tracker/src/Components/NewIssue/NewIssue.tsx
@@ -10,6 +10,7 @@ import CreateButton from "./CreateButton";
 import UnCreateButton from "./UnCreateButton";
 import SettingSideBar from "@/Components/AtomicComponents/SettingSideBar/SettingSideBar";
 import Editor from "@/Components/AtomicComponents/Editor/Editor";
+import Header from "@/Components/Header/Header";
 import { NewIssue as S } from "@/Components/NewIssue/NewIssueStyles";
 
 const NewIssue = () => {
@@ -32,35 +33,38 @@ const NewIssue = () => {
   };
 
   return (
-    <S.NewIssue>
-      <Title />
-      <S.NewIssueBody>
-        <MyIcon />
-        <S.BodyContentsWrapper>
-          <S.TextAreaWrapper>
-            <TextArea
-              placeholder={"제목"}
-              rows={1}
-              handleOnChange={handleTextAreaOnChange}
+    <>
+      <Header />
+      <S.NewIssue>
+        <Title />
+        <S.NewIssueBody>
+          <MyIcon />
+          <S.BodyContentsWrapper>
+            <S.TextAreaWrapper>
+              <TextArea
+                placeholder={"제목"}
+                rows={1}
+                handleOnChange={handleTextAreaOnChange}
+              />
+            </S.TextAreaWrapper>
+            <Editor
+              value={"### 코멘트를 입력하세요"}
+              height={400}
+              visiableDragbar={false}
+              hideToolbar={true}
+              handleOnChange={handleEditorOnChange}
             />
-          </S.TextAreaWrapper>
-          <Editor
-            value={"### 코멘트를 입력하세요"}
-            height={400}
-            visiableDragbar={false}
-            hideToolbar={true}
-            handleOnChange={handleEditorOnChange}
-          />
-        </S.BodyContentsWrapper>
-        <S.NavWrapper>
-          <SettingSideBar />
-        </S.NavWrapper>
-      </S.NewIssueBody>
-      <S.ButtonsWrapper>
-        <UnCreateButton />
-        <CreateButton />
-      </S.ButtonsWrapper>
-    </S.NewIssue>
+          </S.BodyContentsWrapper>
+          <S.NavWrapper>
+            <SettingSideBar />
+          </S.NavWrapper>
+        </S.NewIssueBody>
+        <S.ButtonsWrapper>
+          <UnCreateButton />
+          <CreateButton />
+        </S.ButtonsWrapper>
+      </S.NewIssue>
+    </>
   );
 };
 

--- a/FE/issue-tracker/src/Components/NewIssue/NewIssueStyles.tsx
+++ b/FE/issue-tracker/src/Components/NewIssue/NewIssueStyles.tsx
@@ -12,7 +12,7 @@ const NewIssue = {
   Title: styled.div`
     font-size: ${theme.FONT_SIZE.DISPLAY};
     color: ${theme.GRAY_SCALE.TITLE_ACTIVE};
-    padding: 32px 0px;
+    padding-bottom: 32px;
     border-bottom: 1px solid ${theme.GRAY_SCALE.LINE};
     width: 100%;
   `,


### PR DESCRIPTION
- 이슈 생성, 상세 페이지에 헤더 적용
- 데이터 통신 API를 제외한 기능 구현 완료